### PR TITLE
Fixed sass string concatenation issue

### DIFF
--- a/src/sass/glide.core.scss
+++ b/src/sass/glide.core.scss
@@ -1,6 +1,6 @@
 .glide {
 
-	$that: .glide !default;
+	$that: '.glide' !default;
 
 	position: relative;
 	width: 100%;

--- a/src/sass/glide.theme.scss
+++ b/src/sass/glide.theme.scss
@@ -1,6 +1,6 @@
 .glide {
 
-	$that: .glide !default;
+	$that: '.glide' !default;
 
 	&__wrapper {}
 


### PR DESCRIPTION
Compiling resulted in invalid CSS error; changed `$that: .glide !default` to `$that: '.glide' !default`