### PR TITLE
Fix compatibility issue with use strict

### DIFF
--- a/src/modules/Touch.js
+++ b/src/modules/Touch.js
@@ -213,6 +213,7 @@ var Touch = function(Glide, Core) {
             }
 
             // Switch distance limit base on event type
+            var distanceLimiter;
             if (event.type === 'mouseup' || event.type === 'mouseleave') {
                 distanceLimiter = Glide.options.dragDistance;
             } else {


### PR DESCRIPTION
We’re using Glide.js in a project with “use strict”, and were seeing a “distanceLimiter is undefined” error because of the missing variable declaration.

This commit fixes the issue and allows Glide.js to run in “use strict” environments.